### PR TITLE
AI model names updated in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ settings:<br/>
 
 ##### Preferred AI Model Type
 By default AI Model Type is set to ```ADVANCED``` and it can be overridden by running ```bito -m <BASIC/ADVANCED>```
-Model type is used for AI query in the current session. Model type can be set to BASIC/ADVANCED, which is case insensitive.
+Model type is used for AI query in the current session. Model type can be set to ```BASIC``` or ```ADVANCED```, which is case insensitive.
 
-"ADVANCED" refers to AI models like GPT-4 and Claude 2, while "BASIC" refers to AI models like GPT-3.5 Turbo and Claude Instant.
+"ADVANCED" refers to AI models like GPT-4o, Claude Sonnet 3.5, and best in class AI models, while "BASIC" refers to AI models like GPT-4o mini and similar models. 
 
 When using BASIC AI models, your prompts and the chat's memory are limited to 40,000 characters (about 18 single-spaced pages). However, with ADVANCED AI models, your prompts and the chat memory can go up to 240,000 characters (about 110 single-spaced pages). This means that ADVANCED models can process your entire code files, leading to more accurate answers.
 


### PR DESCRIPTION
For "ADVANCED" requests, we now use GPT-4o and Claude Sonnet 3.5.

For "BASIC" requests, we now use GPT-4o mini and similar models.